### PR TITLE
Colorcolumn now uses comment colour

### DIFF
--- a/lua/decay/config.lua
+++ b/lua/decay/config.lua
@@ -27,7 +27,7 @@ M.highlights_base = function (colors)
     VertSplit = { guifg = colors.background, guibg = colors.color0 },
     CursorLine = { guibg = colors.cursorline },
     CursorColumn = { guibg = colors.background },
-    ColorColumn = { guibg = colors.background },
+    ColorColumn = { guibg = colors.comments },
     NormalFloat = { guibg = colors.background },
     Visual = { guibg = colors.color0, guifg = colors.foreground },
     VisualNOS = { guibg = colors.background },


### PR DESCRIPTION
Using the decay theme for nvim and alacritty at the same time makes the colorcolumn practically invisible. This PR changes it to use the same colour as code comments (that were changed after our discussion on the /r/unixporn discord a while ago) to make it more visible against all black. The screenshot below shows what I mean. Potentially, the same change may be desirable for the `cursorline` as well (which is also active in the screenshot)

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/60970073/177523524-a144f6ea-2816-4b28-a3fc-b7591fd234d2.png">
